### PR TITLE
Fix stylesheet for multiple user cards

### DIFF
--- a/assets/stylesheets/common/locations.scss
+++ b/assets/stylesheets/common/locations.scss
@@ -664,7 +664,7 @@ input.input-location, div.input-location {
   margin-top: 5px;
 }
 
-#user-card .location-and-website.map-location-enabled {
+.user-card .location-and-website.map-location-enabled {
   .location,
   .website-name {
     display: none;


### PR DESCRIPTION
Discourse core styling was switched to use `.user-card` instead of `#user-card` (to allow for multiple cards to be rendered simultaneously). 

https://github.com/discourse/discourse/commit/8d50f092b56f6cff9e4ba8f8aafaa21d455b134a