### PR TITLE
fix: german locale root

### DIFF
--- a/config/locales/client.de.yml
+++ b/config/locales/client.de.yml
@@ -1,4 +1,4 @@
-en:
+de:
   js:
     category:
       location_enabled: "Zulassen, dass Standorte zu Themen in dieser Kategorie hinzugefügt werden"


### PR DESCRIPTION
Currently the german locale file uses ```en``` as a root node but needs to be ```de``` to show correct german translations