### PR TITLE
switch to topic.url instead of calculating the url

### DIFF
--- a/assets/javascripts/discourse/widgets/map.js.es6
+++ b/assets/javascripts/discourse/widgets/map.js.es6
@@ -91,7 +91,7 @@ export default createWidget('map', {
     if (!location['marker'] && !location['circle_marker']) {
       location['marker'] = {
         title: topic.fancy_title,
-        routeTo: "/t/" + topic.slug
+        routeTo: topic.url
       };
     }
 


### PR DESCRIPTION
By computing the slug, we introduce an additional redirect which messes
up the browser navigation stack. When the correct URL is used in the
first place, routing behaves as expected.

Before this fix, the following navigation issue appeared:
* Page A
* `/map`
* Page B
* _user uses the back button of the browser_
* Page A

Instead, the user should've been taken back to the map.
This change accomplishes this.