### PR TITLE
DEV: Register location-format for use with raw-hbs template

### DIFF
--- a/assets/javascripts/discourse/helpers/location-format.js
+++ b/assets/javascripts/discourse/helpers/location-format.js
@@ -1,8 +1,9 @@
 import { htmlSafe } from "@ember/template";
-import { helperContext } from "discourse-common/lib/helpers";
+import { helperContext, registerRawHelper } from "discourse-common/lib/helpers";
 import { locationFormat } from "../lib/location-utilities";
 import Site from "discourse/models/site";
 
+registerRawHelper("location-format", _locationFormat);
 export default function _locationFormat(location, opts) {
   let siteSettings = helperContext().siteSettings;
   return htmlSafe(

--- a/plugin.rb
+++ b/plugin.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 # name: discourse-locations
 # about: Tools for handling locations in Discourse
-# version: 6.3.14
+# version: 6.3.15
 # authors: Angus McLeod, Robert Barrow
 # contact_emails: development@pavilion.tech
 # url: https://github.com/angusmcleod/discourse-locations


### PR DESCRIPTION
Followup #98.

`location-format` is used in _one_ raw-hbs template. 

I did check before, but among all the `hbs` files, I shamefully missed this one `hbr`. 
Even while testing, I did not notice it. I will be extra careful next time. My bad :(