### PR TITLE
FIX: can access user profile page if the user hide its public profile and `location_users_map` is true

### DIFF
--- a/assets/javascripts/discourse/connectors/user-location-and-website/replace-location.js.es6
+++ b/assets/javascripts/discourse/connectors/user-location-and-website/replace-location.js.es6
@@ -11,7 +11,7 @@ export default {
 
       component.set(
         "showUserLocation",
-        !!args.model.custom_fields.geo_location
+        !!args.model.custom_fields?.geo_location
       );
       component.set("linkWebsite", !args.model.isBasic);
     }


### PR DESCRIPTION
I find accessing the `u/<username>` page hangs when both
* `location users map` (allow users to add a geocoded location which is displayed on a map in the Users section)
* `hide my public profile and presence features` in `/my/preferences/interface`
are true.